### PR TITLE
Fix for Menu.php

### DIFF
--- a/astroid/astroid-framework/framework/library/astroid/Component/Menu.php
+++ b/astroid/astroid-framework/framework/library/astroid/Component/Menu.php
@@ -15,7 +15,7 @@ use Astroid\Framework;
 
 if (ASTROID_JOOMLA_VERSION == 3) {
     \JLoader::register('ModMenuHelper', JPATH_SITE . '/modules/mod_menu/helper.php');
-    \JLoader::registerAlias('MenuHelper', 'ModMenuHelper');
+    //\JLoader::registerAlias('MenuHelper', 'ModMenuHelper');
 } else {
     \JLoader::registerAlias('MenuHelper', '\\Joomla\\Module\\Menu\\Site\\Helper\\MenuHelper');
 }
@@ -46,10 +46,10 @@ class Menu
         $menu_params = new \JRegistry();
         $menu_params->loadString($header_menu_params);
 
-        $list = \MenuHelper::getList($menu_params);
-        $base = \MenuHelper::getBase($menu_params);
-        $active = \MenuHelper::getActive($menu_params);
-        $default = \MenuHelper::getDefault();
+        $list = \ModMenuHelper::getList($menu_params);
+        $base = \ModMenuHelper::getBase($menu_params);
+        $active = \ModMenuHelper::getActive($menu_params);
+        $default = \ModMenuHelper::getDefault();
 
         $active_id = $active->id;
         $default_id = $default->id;
@@ -573,10 +573,10 @@ class Menu
         $menu_params = new \JRegistry();
         $menu_params->loadString($header_menu_params);
 
-        $list = \MenuHelper::getList($menu_params);
-        $base = \MenuHelper::getBase($menu_params);
-        $active = \MenuHelper::getActive($menu_params);
-        $default = \MenuHelper::getDefault();
+        $list = \ModMenuHelper::getList($menu_params);
+        $base = \ModMenuHelper::getBase($menu_params);
+        $active = \ModMenuHelper::getActive($menu_params);
+        $default = \ModMenuHelper::getDefault();
 
         $active_id = $active->id;
         $default_id = $default->id;


### PR DESCRIPTION
When you have the error.
ERROR 0 - Call to undefined method MenuHelper::getList() in /public_html/test/libraries/astroid/framework/library/astroid/Component/Menu.php:576

This removes Joomla 4 Compatibility but works for now.